### PR TITLE
IdP configuration for internal use

### DIFF
--- a/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/picketlink.xml
+++ b/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/picketlink.xml
@@ -1,11 +1,11 @@
 <PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
 	<PicketLinkIDP xmlns="urn:picketlink:identity-federation:config:2.1"
-                   SupportsSignatures="true"
-                   Encrypt="true"
+                   SupportsSignatures="false"
+                   Encrypt="false"
                    AttributeManager="org.picketlink.identity.federation.bindings.wildfly.idp.UndertowAttributeManager"
                    RoleGenerator="org.picketlink.identity.federation.bindings.wildfly.idp.UndertowRoleGenerator">
         <Trust>
-			<Domains>localhost,jboss.com,jboss.org,amazonaws.com</Domains>
+			<Domains>localhost,immut-saml-test,jboss.com,jboss.org,amazonaws.com</Domains>
 		</Trust>
 		<KeyProvider
 			ClassName="org.picketlink.identity.federation.core.impl.KeyStoreKeyManager">

--- a/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/picketlink.xml
+++ b/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/picketlink.xml
@@ -4,8 +4,9 @@
                    Encrypt="false"
                    AttributeManager="org.picketlink.identity.federation.bindings.wildfly.idp.UndertowAttributeManager"
                    RoleGenerator="org.picketlink.identity.federation.bindings.wildfly.idp.UndertowRoleGenerator">
-        <Trust>
-			<Domains>localhost,immut-saml-test,jboss.com,jboss.org,amazonaws.com</Domains>
+		<IdentityURL>http://127.0.0.1:8080/idp-metadata/</IdentityURL>
+		<Trust>
+			<Domains>127.0.0.1,localhost,cenx.com,cenx-conduit,immut-saml-test,jboss.com,jboss.org,amazonaws.com</Domains>
 		</Trust>
 		<KeyProvider
 			ClassName="org.picketlink.identity.federation.core.impl.KeyStoreKeyManager">
@@ -20,9 +21,9 @@
 			<ValidatingAlias Key="localhost" Value="servercert" />
 			<ValidatingAlias Key="127.0.0.1" Value="servercert" />
 		</KeyProvider>
-        <MetaDataProvider ClassName="org.picketlink.identity.federation.core.saml.md.providers.FileBasedEntitiesMetadataProvider">
-            <Option Key="FileName" Value="/WEB-INF/classes/sp-metadata.xml"/>
-        </MetaDataProvider>
+		<MetaDataProvider ClassName="org.picketlink.identity.federation.core.saml.md.providers.FileBasedEntitiesMetadataProvider">
+			<Option Key="FileName" Value="/WEB-INF/classes/sp-metadata.xml"/>
+		</MetaDataProvider>
 	</PicketLinkIDP>
 	<Handlers xmlns="urn:picketlink:identity-federation:handler:config:2.1">
 		<Handler
@@ -35,7 +36,7 @@
 			class="org.picketlink.identity.federation.web.handlers.saml2.RolesGenerationHandler" />
 		<Handler
 			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2EncryptionHandler" />
-      	<Handler
-            class="org.picketlink.identity.federation.web.handlers.saml2.SAML2SignatureValidationHandler" />
+		<Handler
+		    class="org.picketlink.identity.federation.web.handlers.saml2.SAML2SignatureValidationHandler" />
 	</Handlers>
 </PicketLink>

--- a/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/web.xml
+++ b/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/web.xml
@@ -4,9 +4,7 @@
 	version="2.5">
 
     <display-name>PicketLink Identity Provider</display-name>
-
 	<description>PicketLink Identity Provider With a Basic Configuration</description>
-
 	<listener>
 		<listener-class>org.picketlink.identity.federation.web.listeners.IDPHttpSessionListener</listener-class>
 	</listener>
@@ -27,7 +25,7 @@
         <filter-name>IDPFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
-    
+
 	<!-- Define a security constraint that gives unlimited access to some static resources. -->
 	<security-constraint>
 		<web-resource-collection>
@@ -43,21 +41,18 @@
 	<!-- Define a Security Constraint on this application. -->
 	<security-constraint>
 		<web-resource-collection>
-			<web-resource-name>Manager command</web-resource-name>
+			<web-resource-name>all resources</web-resource-name>
 			<url-pattern>/*</url-pattern>
 		</web-resource-collection>
 		<auth-constraint>
-			<role-name>manager</role-name>
-			<role-name>Sales</role-name>
-			<role-name>Employee</role-name>
-			<role-name>user</role-name>
+			<role-name>*</role-name>
 		</auth-constraint>
 	</security-constraint>
 
 	<!-- Define the Login Configuration for this application. -->
 	<login-config>
 		<auth-method>FORM</auth-method>
-		<realm-name>PicketLink IDP Application</realm-name>
+		<realm-name>ldap</realm-name>
 		<form-login-config>
 			<form-login-page>/jsp/login.jsp</form-login-page>
 			<form-error-page>/jsp/login-error.jsp</form-error-page>
@@ -66,15 +61,6 @@
 
 	<!-- Security roles referenced by this web application. -->
 	<security-role>
-		<role-name>manager</role-name>
-	</security-role>
-	<security-role>
-		<role-name>Sales</role-name>
-	</security-role>
-	<security-role>
-		<role-name>Employee</role-name>
-	</security-role>
-	<security-role>
-		<role-name>user</role-name>
+		<role-name>*</role-name>
 	</security-role>
 </web-app>

--- a/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/web.xml
+++ b/picketlink-federation-saml-idp-with-metadata/conf/wildfly/WEB-INF/web.xml
@@ -50,6 +50,7 @@
 			<role-name>manager</role-name>
 			<role-name>Sales</role-name>
 			<role-name>Employee</role-name>
+			<role-name>user</role-name>
 		</auth-constraint>
 	</security-constraint>
 
@@ -72,5 +73,8 @@
 	</security-role>
 	<security-role>
 		<role-name>Employee</role-name>
+	</security-role>
+	<security-role>
+		<role-name>user</role-name>
 	</security-role>
 </web-app>

--- a/picketlink-federation-saml-idp-with-metadata/src/main/resources/idp-metadata.xml
+++ b/picketlink-federation-saml-idp-with-metadata/src/main/resources/idp-metadata.xml
@@ -2,7 +2,6 @@
 <EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" >
 	<EntityDescriptor entityID="http://127.0.0.1:8080/idp-metadata/">
 		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:2.0:protocol">
-		    </KeyDescriptor>
 			<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
 			</NameIDFormat>
 			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"

--- a/picketlink-federation-saml-idp-with-metadata/src/main/resources/idp-metadata.xml
+++ b/picketlink-federation-saml-idp-with-metadata/src/main/resources/idp-metadata.xml
@@ -55,7 +55,7 @@ lTz3UNkn6k2iagzYdJdnhgRZGpRWjf1t4skoJjvfL3HwkOWhSFKundbKcZSZwifI
                     </dsig:X509Data>
                 </dsig:KeyInfo>
 		    </KeyDescriptor>
-			<NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient
+			<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
 			</NameIDFormat>
 			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
 				Location="http://localhost:8080/idp-metadata/" />

--- a/picketlink-federation-saml-idp-with-metadata/src/main/resources/idp-metadata.xml
+++ b/picketlink-federation-saml-idp-with-metadata/src/main/resources/idp-metadata.xml
@@ -1,77 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two"
-                    xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-    >
-	<EntityDescriptor entityID="http://localhost:8080/idp-metadata/">
+<EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" >
+	<EntityDescriptor entityID="http://127.0.0.1:8080/idp-metadata/">
 		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:2.0:protocol">
-            <KeyDescriptor use="signing">
-                <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
-                    <dsig:X509Data>
-                        <dsig:X509Certificate>
-                            MIIB9DCCAV0CBElvalIwDQYJKoZIhvcNAQEEBQAwQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpC
-b3NzMQ4wDAYDVQQLEwVKQm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MB4XDTA5MDExNTE2NTQ0MloX
-DTA5MDQxNTE2NTQ0MlowQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpCb3NzMQ4wDAYDVQQLEwVK
-Qm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDsqJo7
-vBYZ9+tlxfItxjezJntNZUTnAHNTTz8O+CVO+9JB6i2YkMoFN5rw3wp/xIqp0EA0fx2dhPTBFeR5
-0BD73tjDBYqLBPP4Qdi9/AFZBpXcEG7aQtV73D6HKRc+YQQhDNddt+gG33GLmnCisOyMklE6J8rn
-55S2MgraOQbMowIDAQABMA0GCSqGSIb3DQEBBAUAA4GBAFthl5SFim6NXCsRzOl8VHDdrIskk9i5
-71zQLEI1BW24IiDtAgQBY6YXb1kkEJ6GmlW44IWIBZLTRerYXAivdJTdW+9D+HCapByQeNfj7HnQ
-lTz3UNkn6k2iagzYdJdnhgRZGpRWjf1t4skoJjvfL3HwkOWhSFKundbKcZSZwifI
-                        </dsig:X509Certificate>
-                    </dsig:X509Data>
-                </dsig:KeyInfo>
-		    </KeyDescriptor>
-		    <KeyDescriptor use="encryption">
-                <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
-                    <dsig:X509Data>
-                        <dsig:X509Certificate>
-                            MIIB9DCCAV0CBElvalIwDQYJKoZIhvcNAQEEBQAwQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpC
-b3NzMQ4wDAYDVQQLEwVKQm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MB4XDTA5MDExNTE2NTQ0MloX
-DTA5MDQxNTE2NTQ0MlowQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpCb3NzMQ4wDAYDVQQLEwVK
-Qm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDsqJo7
-vBYZ9+tlxfItxjezJntNZUTnAHNTTz8O+CVO+9JB6i2YkMoFN5rw3wp/xIqp0EA0fx2dhPTBFeR5
-0BD73tjDBYqLBPP4Qdi9/AFZBpXcEG7aQtV73D6HKRc+YQQhDNddt+gG33GLmnCisOyMklE6J8rn
-55S2MgraOQbMowIDAQABMA0GCSqGSIb3DQEBBAUAA4GBAFthl5SFim6NXCsRzOl8VHDdrIskk9i5
-71zQLEI1BW24IiDtAgQBY6YXb1kkEJ6GmlW44IWIBZLTRerYXAivdJTdW+9D+HCapByQeNfj7HnQ
-lTz3UNkn6k2iagzYdJdnhgRZGpRWjf1t4skoJjvfL3HwkOWhSFKundbKcZSZwifI
-                        </dsig:X509Certificate>
-                    </dsig:X509Data>
-                </dsig:KeyInfo>
-		    </KeyDescriptor>
-            <KeyDescriptor>
-                <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
-                    <dsig:X509Data>
-                        <dsig:X509Certificate>
-                            MIIB9DCCAV0CBElvalIwDQYJKoZIhvcNAQEEBQAwQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpC
-b3NzMQ4wDAYDVQQLEwVKQm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MB4XDTA5MDExNTE2NTQ0MloX
-DTA5MDQxNTE2NTQ0MlowQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpCb3NzMQ4wDAYDVQQLEwVK
-Qm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDsqJo7
-vBYZ9+tlxfItxjezJntNZUTnAHNTTz8O+CVO+9JB6i2YkMoFN5rw3wp/xIqp0EA0fx2dhPTBFeR5
-0BD73tjDBYqLBPP4Qdi9/AFZBpXcEG7aQtV73D6HKRc+YQQhDNddt+gG33GLmnCisOyMklE6J8rn
-55S2MgraOQbMowIDAQABMA0GCSqGSIb3DQEBBAUAA4GBAFthl5SFim6NXCsRzOl8VHDdrIskk9i5
-71zQLEI1BW24IiDtAgQBY6YXb1kkEJ6GmlW44IWIBZLTRerYXAivdJTdW+9D+HCapByQeNfj7HnQ
-lTz3UNkn6k2iagzYdJdnhgRZGpRWjf1t4skoJjvfL3HwkOWhSFKundbKcZSZwifI
-                        </dsig:X509Certificate>
-                    </dsig:X509Data>
-                </dsig:KeyInfo>
 		    </KeyDescriptor>
 			<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
 			</NameIDFormat>
 			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
-				Location="http://localhost:8080/idp-metadata/" />
+				Location="http://127.0.0.1:8080/idp-metadata/" />
 			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-				Location="http://localhost:8080/idp-metadata/" />
+				Location="http://127.0.0.1:8080/idp-metadata/" />
 			<SingleSignOnService
 				Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-				Location="http://localhost:8080/idp-metadata/" />
+				Location="http://127.0.0.1:8080/idp-metadata/" />
 		</IDPSSODescriptor>
 		<Organization>
-			<OrganizationName xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-				xml:lang="en">JBoss</OrganizationName>
-			<OrganizationDisplayName xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-				xml:lang="en">JBoss by Red Hat</OrganizationDisplayName>
-			<OrganizationURL xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-				xml:lang="en">http://www.jboss.org</OrganizationURL>
+			<OrganizationName xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xml:lang="en">JBoss</OrganizationName>
+			<OrganizationDisplayName xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xml:lang="en">JBoss by Red Hat</OrganizationDisplayName>
+			<OrganizationURL xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xml:lang="en">http://www.jboss.org</OrganizationURL>
 		</Organization>
 		<ContactPerson contactType="technical">
 			<GivenName>The</GivenName>

--- a/picketlink-federation-saml-idp-with-metadata/src/main/resources/sp-metadata.xml
+++ b/picketlink-federation-saml-idp-with-metadata/src/main/resources/sp-metadata.xml
@@ -1,68 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two"
-                    xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-    >
-	<EntityDescriptor entityID="http://localhost:8080/sales-metadata/">
-		<SPSSODescriptor
-			protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol http://schemas.xmlsoap.org/ws/2003/07/secext">
-                    <KeyDescriptor use="signing">
-                        <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
-                            <dsig:X509Data>
-                                <dsig:X509Certificate>
-                                    MIIB9DCCAV0CBElvalIwDQYJKoZIhvcNAQEEBQAwQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpC
-                                    b3NzMQ4wDAYDVQQLEwVKQm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MB4XDTA5MDExNTE2NTQ0MloX
-                                    DTA5MDQxNTE2NTQ0MlowQTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBUpCb3NzMQ4wDAYDVQQLEwVK
-                                    Qm9zczESMBAGA1UEAxMJamJpZCB0ZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDsqJo7
-                                    vBYZ9+tlxfItxjezJntNZUTnAHNTTz8O+CVO+9JB6i2YkMoFN5rw3wp/xIqp0EA0fx2dhPTBFeR5
-                                    0BD73tjDBYqLBPP4Qdi9/AFZBpXcEG7aQtV73D6HKRc+YQQhDNddt+gG33GLmnCisOyMklE6J8rn
-                                    55S2MgraOQbMowIDAQABMA0GCSqGSIb3DQEBBAUAA4GBAFthl5SFim6NXCsRzOl8VHDdrIskk9i5
-                                    71zQLEI1BW24IiDtAgQBY6YXb1kkEJ6GmlW44IWIBZLTRerYXAivdJTdW+9D+HCapByQeNfj7HnQ
-                                    lTz3UNkn6k2iagzYdJdnhgRZGpRWjf1t4skoJjvfL3HwkOWhSFKundbKcZSZwifI
-                                </dsig:X509Certificate>
-                            </dsig:X509Data>
-                        </dsig:KeyInfo>
-                    </KeyDescriptor>
-                    <KeyDescriptor use="encryption">
-                        <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
-                            <dsig:X509Data>
-                                <dsig:X509Certificate>
-                                    MIIDdzCCAl+gAwIBAgIEGaqw6DANBgkqhkiG9w0BAQsFADBsMRAwDgYDVQQGEwdVbmtub3duMRAw
-                                    DgYDVQQIEwdVbmtub3duMRAwDgYDVQQHEwdVbmtub3duMRAwDgYDVQQKEwdVbmtub3duMRAwDgYD
-                                    VQQLEwdVbmtub3duMRAwDgYDVQQDEwdVbmtub3duMB4XDTE0MTAyMTEyMDgxOVoXDTE1MDExOTEy
-                                    MDgxOVowbDEQMA4GA1UEBhMHVW5rbm93bjEQMA4GA1UECBMHVW5rbm93bjEQMA4GA1UEBxMHVW5r
-                                    bm93bjEQMA4GA1UEChMHVW5rbm93bjEQMA4GA1UECxMHVW5rbm93bjEQMA4GA1UEAxMHVW5rbm93
-                                    bjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIumwmzwBjCnFai02NJaD7FZ13CnWDLI
-                                    IYmlgvOc/jXIZdb7MpBcp4sP0c8ziJ/YoF4aBARLDQB1uSEHjVEvGvoFqx2riPY75MWen35fK5cx
-                                    6WqnLdqOBG8bn8Ja3ecta52KTMo0qDX8XdKy2EJksxU5IHRlIqsn0Fym5iPi/ALQHnMT9jdBqO3Z
-                                    YOtV5hy0ULp6hVOSEUbcVsNgxmmvDghRcmf/+BiJ2jknZ2+cFWt2SrrIChCUzvTEbx7D5fDD2T0N
-                                    0a3YpPw2sV6RBOSUEX77YYvza+tSJkuxxoIBmDxJkKL+6GWMN/eyoNJIP4uZHQ5jKyuQqPooGCh/
-                                    kRAEXmsCAwEAAaMhMB8wHQYDVR0OBBYEFGZsQ0M8zlMdMVaFIpgV1+k5ebUvMA0GCSqGSIb3DQEB
-                                    CwUAA4IBAQAJBrDPNsx0QXz7UdUM8+26Ffi3HWX5VFSGWVaRHRGbd7mL666OVZ7v/1AkzW3/M/04
-                                    HZ45h0o6VobsynebXX/ec9k10ipC1ER31oOCHp60mMTJsXZM+8lbhADOhHED/7/4ktrV7KQPrw/3
-                                    7X8s3qBAEO0Vdvxy/oreDC5igmhj3dh5Q5l5eKv2Nd/oMNQdtMuhFqMc66cW2pEjHt//Q4m7A3tE
-                                    pyysrwvRPmIRwGC/NsIH+CCWSuugRPJ2ZB5zFJk5J4fS9mEbiD8+WHnp/BEEQyESO93ff7Aqg4IX
-                                    zOdfKSSCy7tdpE5u5k28h8dw2jfC+epDHkwU5NwiZzo8Sl9R
-                                </dsig:X509Certificate>
-                            </dsig:X509Data>
-                        </dsig:KeyInfo>
-                    </KeyDescriptor>
-                    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</NameIDFormat>
-                    <AssertionConsumerService
-                            Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8080/sales-metadata/"
-                            index="1" isDefault="true" />
-		</SPSSODescriptor>
-		<Organization>
-			<OrganizationName xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-				xml:lang="en">JBoss</OrganizationName>
-			<OrganizationDisplayName xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-				xml:lang="en">JBoss by Red Hat</OrganizationDisplayName>
-			<OrganizationURL xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-				xml:lang="en">http://localhost:8080/sales-metadata/</OrganizationURL>
-		</Organization>
-		<ContactPerson contactType="technical">
-			<GivenName>The</GivenName>
-			<SurName>Admin</SurName>
-			<EmailAddress>admin@mycompany.com</EmailAddress>
-		</ContactPerson>
+<EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+	<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="cenx-apollo">
+	    <SPSSODescriptor AuthnRequestsSigned="false"
+	            protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol http://schemas.xmlsoap.org/ws/2003/07/secext">
+	        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://127.0.0.1:8080/network"/>
+	        <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
+	        </NameIDFormat>
+	        <AssertionConsumerService
+	                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://127.0.0.1:8080/network"
+	                index="1" isDefault="true" />
+	    </SPSSODescriptor>
+	</EntityDescriptor>
+	<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="cenx-babelfish">
+	    <SPSSODescriptor AuthnRequestsSigned="false"
+	            protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol http://schemas.xmlsoap.org/ws/2003/07/secext">
+	        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://127.0.0.1:8080/reports"/>
+	        <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
+	        </NameIDFormat>
+	        <AssertionConsumerService
+	                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://med10.cenx.localnet:8080/reports"
+	                index="1" isDefault="true" />
+	    </SPSSODescriptor>
+	</EntityDescriptor>
+	<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="cenx-conduit">
+	    <SPSSODescriptor AuthnRequestsSigned="false"
+	            protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol http://schemas.xmlsoap.org/ws/2003/07/secext">
+	        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://127.0.0.1:8080/"/>
+	        <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
+	        </NameIDFormat>
+	        <AssertionConsumerService
+	                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://127.0.0.1:8080/"
+	                index="1" isDefault="true" />
+	    </SPSSODescriptor>
 	</EntityDescriptor>
 </EntitiesDescriptor>

--- a/picketlink-federation-saml-idp-with-metadata/src/main/resources/sp-metadata.xml
+++ b/picketlink-federation-saml-idp-with-metadata/src/main/resources/sp-metadata.xml
@@ -46,7 +46,7 @@
                             </dsig:X509Data>
                         </dsig:KeyInfo>
                     </KeyDescriptor>
-                    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+                    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</NameIDFormat>
                     <AssertionConsumerService
                             Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8080/sales-metadata/"
                             index="1" isDefault="true" />

--- a/picketlink-federation-saml-sp-with-metadata/src/main/resources/idp-metadata.xml
+++ b/picketlink-federation-saml-sp-with-metadata/src/main/resources/idp-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two"
                     xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://ckirkendall-dev-ed.my.salesforce.com" validUntil="2026-08-11T18:39:34.074Z" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:8080/idp-metadata" validUntil="2026-08-11T18:39:34.074Z" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
    <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
       <md:KeyDescriptor use="signing">
          <ds:KeyInfo>
@@ -11,8 +11,9 @@
          </ds:KeyInfo>
       </md:KeyDescriptor>
       <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
-      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://ckirkendall-dev-ed.my.salesforce.com/idp/endpoint/HttpPost"/>
-      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://ckirkendall-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"/>
+      <md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="http://localhost:8080/idp-metadata/" />
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8080/idp-metadata/" />
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:8080/idp-metadata" />
    </md:IDPSSODescriptor>
 </md:EntityDescriptor>
 </EntitiesDescriptor>

--- a/picketlink-federation-saml-sp-with-metadata/src/main/resources/sp-metadata.xml
+++ b/picketlink-federation-saml-sp-with-metadata/src/main/resources/sp-metadata.xml
@@ -1,5 +1,5 @@
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="immut-saml-test">
-    <SPSSODescriptor AuthnRequestsSigned="false"
+    <SPSSODescriptor AuthnRequestsSigned="true"
             protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol http://schemas.xmlsoap.org/ws/2003/07/secext">
         <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8080/sales-metadata/"/>
         <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified

--- a/picketlink-federation-saml-sp-with-metadata/src/main/webapp/WEB-INF/picketlink.xml
+++ b/picketlink-federation-saml-sp-with-metadata/src/main/webapp/WEB-INF/picketlink.xml
@@ -1,6 +1,6 @@
 <PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
 	<PicketLinkSP xmlns="urn:picketlink:identity-federation:config:2.1"
-		ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="false">
+		ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="false" Encrypt="false">
 
         <MetaDataProvider ClassName="org.picketlink.identity.federation.core.saml.md.providers.FileBasedEntitiesMetadataProvider">
             <Option Key="FileName" Value="/WEB-INF/classes/idp-metadata.xml"/>


### PR DESCRIPTION
Modify quickstart configuration for idp-with-metadata to provide an
identity provider for use with sp-with-metadata. The IdP works without
signature verification or encryption, so is unsuitable for use in prod
but can be used as a starting point for further investigation, or for
testing to ensure a SAML login path is working.

This IdP requires an idp security domain to be defined in wildfly,
there is one available that is distributed separately from this git
repo.
